### PR TITLE
Add support for latest famo.us version

### DIFF
--- a/app/css/index.coffee
+++ b/app/css/index.coffee
@@ -1,0 +1,1 @@
+require 'famous/core/famous.css'

--- a/app/css/main.sass
+++ b/app/css/main.sass
@@ -35,9 +35,6 @@ table
   border-collapse: collapse
   border-spacing: 0
 
-// Import Famo.us's CSS
-@import bower_components/famous/core/famous.css
-
 // Import Colors
 @import bower_components/colors/sass/colors
 

--- a/app/js/main.coffee
+++ b/app/js/main.coffee
@@ -1,7 +1,10 @@
 'use strict'
 
+# Import Famo.us CSS
+require '../css'
+
 # Use Famo.us polyfills: Universal access to CSS3 transforms
-require 'famous-polyfills/index'
+require 'famous-polyfills'
 
 # Get nice colors
 require 'colors/coffee/colors'

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,6 @@
     "tests"
   ],
   "dependencies": {
-    "famous-polyfills": "git@github.com:Famous/polyfills.git#",
-    "famous": "git@github.com:Famous/famous.git#v0.2.2",
     "colors": "https://github.com/mrmrs/colors.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,21 @@
   },
   "author": "PEM--",
   "license": "MIT",
-  "dependencies": {},
+  "browserify": {
+    "transform": [
+      "famousify",
+      "cssify",
+      "brfs"
+    ]
+  },
+  "dependencies": {
+    "famousify": "^0.1.5",
+    "brfs": "^1.2.0",
+    "cssify": "^0.6.0",
+    "famous": "0.3.3",
+    "famous-polyfills": "^0.3.0",
+    "famousify": "^0.1.5"
+  },
   "devDependencies": {
     "browserify": "^4.2.0",
     "coffee-script": "^1.7.1",


### PR DESCRIPTION
Support for latest famo.us version. Use famous from npm instead of bower as famous team did for browserify seed project.
